### PR TITLE
Remove parsing bug in decode_uri

### DIFF
--- a/src/network/network_utils.c
+++ b/src/network/network_utils.c
@@ -25,7 +25,7 @@ uint8_t decode_uri(char* uri, char** host, char** port)
     } else {
         // split strings
         **port = 0;
-        *port++;
+        (*port)++;
 
     }
 


### PR DESCRIPTION
While incrementing the pointer port, single de-reference should take priority over increment for complete uri to be decoded properly