### PR TITLE
New 'ResourceRaw' class constructor

### DIFF
--- a/src/include/lwm2m/objects.h
+++ b/src/include/lwm2m/objects.h
@@ -369,6 +369,13 @@ public:
     ResourceRaw() : lwm2m_object_res_item_t {ResID,Operations,O_RES_INT64,offset} {}
 };
 
+template<uint16_t ResID, class ObjectInstance, class ResourceType, size_t offset, uint8_t Operations>
+class ResourceRaw<ResID,ObjectInstance, ResourceType, offset, Operations,
+            typename std::enable_if<!std::is_same<int, int32_t>::value && std::is_same<ResourceType, int>::value>::type> : public lwm2m_object_res_item_t {
+public:
+ ResourceRaw() : lwm2m_object_res_item_t {ResID,Operations,O_RES_INT32,offset} {}
+};
+
 //////////// For indirect resources, where we do not need to define operations ///////////
 
 // Fallback for non indirect resources


### PR DESCRIPTION
Lwm2m resources that are of type 'int' fail to build, when using a system where 'int32_t' type is equal to 'long int'. The problem is that in such case the compiler can't find a correct template for the 'ResourceRaw' class builder, and the 'delete' method gets called. One example is 'arm' processor systems. You can see the default 'int32_t' type with command 'arm-none-eabi-gcc -dM -E - < /dev/null | grep __INT32'. My solution is a new, dynamic constructor, which takes into account if types 'int' and 'int32_t' are equal, thus making it compatible with other systems like 'esp'.